### PR TITLE
Fix #7, disallow coords with reduced debug info

### DIFF
--- a/src/main/java/com/umollu/ash/mixin/GameRendererMixin.java
+++ b/src/main/java/com/umollu/ash/mixin/GameRendererMixin.java
@@ -30,7 +30,7 @@ public class GameRendererMixin {
 			if(AshCommands.config.showFps) {
 				ashString += String.format("%d fps ", ((MinecraftClientMixin) MinecraftClient.getInstance()).getCurrentFps());
 			}
-			if(AshCommands.config.showCoords) {
+			if(AshCommands.config.showCoords && !client.hasReducedDebugInfo()) {
 				BlockPos blockPos = new BlockPos(cameraEntity.getX(), cameraEntity.getBoundingBox().getMin(Direction.Axis.Y), cameraEntity.getZ());
 				ashString += String.format("%d %d %d ", blockPos.getX(), blockPos.getY(), blockPos.getZ());
 			}


### PR DESCRIPTION
A _really_ simple fix for a small problem. Dunno what to say, but this should stop me from technically cheating on no-coords servers.