### PR TITLE
Remove Cotton Client Commands dependency and use Fabric API 0.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,6 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation "io.github.cottonmc:cotton-client-commands:${project.clientcommands_version}"
-	include "io.github.cottonmc:cotton-client-commands:${project.clientcommands_version}"
-
 	modApi "me.sargunvohra.mcmods:autoconfig1u:${project.autoconfig_version}"
 	include "me.sargunvohra.mcmods:autoconfig1u:${project.autoconfig_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,7 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = ash
 
 # Dependencies
-	fabric_version=0.25.4+1.16
-	clientcommands_version=1.0.1+1.16-rc1
+	fabric_version=0.31.0+1.16
 	autoconfig_version=3.3.1
 	clothconfig_version=4.8.3
 	modmenu_version=1.14.6+build.31

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/umollu/ash/AshCommands.java
+++ b/src/main/java/com/umollu/ash/AshCommands.java
@@ -3,53 +3,54 @@ package com.umollu.ash;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.umollu.ash.config.AshConfig;
-import io.github.cottonmc.clientcommands.ArgumentBuilders;
-import io.github.cottonmc.clientcommands.ClientCommandPlugin;
-import io.github.cottonmc.clientcommands.CottonClientCommandSource;
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import net.fabricmc.fabric.api.client.command.v1.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
 
-public class AshCommands implements ClientCommandPlugin {
+public class AshCommands {
 
     public static AshConfig config;
 
-    @Override
-        public void registerCommands(CommandDispatcher<CottonClientCommandSource> commandDispatcher) {
+        public static void registerCommands() {
 
+        CommandDispatcher<FabricClientCommandSource> commandDispatcher = ClientCommandManager.DISPATCHER;
+        
+        
         if(config == null) {
             config = AutoConfig.getConfigHolder(AshConfig.class).getConfig();
         }
-        commandDispatcher.register(ArgumentBuilders.literal("toggleash")
+        commandDispatcher.register(ClientCommandManager.literal("toggleash")
             .executes(context -> {
                 config.showHud = !config.showHud;
                 AshMod.configManager.save();
                 return 1;
             }));
 
-        commandDispatcher.register(ArgumentBuilders.literal("togglefps")
+        commandDispatcher.register(ClientCommandManager.literal("togglefps")
             .executes(context -> {
                 config.showFps = !config.showFps;
                 AshMod.configManager.save();
                 return 1;
             }));
 
-        commandDispatcher.register(ArgumentBuilders.literal("togglecoords")
+        commandDispatcher.register(ClientCommandManager.literal("togglecoords")
             .executes(context -> {
                 config.showCoords = !config.showCoords;
                 AshMod.configManager.save();
                 return 1;
             }));
 
-        commandDispatcher.register(ArgumentBuilders.literal("toggledirection")
+        commandDispatcher.register(ClientCommandManager.literal("toggledirection")
             .executes(context -> {
                 config.showDirection = !config.showDirection;
                 AshMod.configManager.save();
                 return 1;
             }));
 
-        commandDispatcher.register(ArgumentBuilders.literal("ashcolor")
-            .then(ArgumentBuilders.argument("r", IntegerArgumentType.integer())
-                    .then(ArgumentBuilders.argument("g", IntegerArgumentType.integer())
-                            .then(ArgumentBuilders.argument("b", IntegerArgumentType.integer())
+        commandDispatcher.register(ClientCommandManager.literal("ashcolor")
+            .then(ClientCommandManager.argument("r", IntegerArgumentType.integer())
+                    .then(ClientCommandManager.argument("g", IntegerArgumentType.integer())
+                            .then(ClientCommandManager.argument("b", IntegerArgumentType.integer())
                                     .executes(context -> {
                                         int r = IntegerArgumentType.getInteger(context,"r");
                                         int g = IntegerArgumentType.getInteger(context,"g");
@@ -60,27 +61,27 @@ public class AshCommands implements ClientCommandPlugin {
                                         return 1;
                                     })))));
 
-        commandDispatcher.register(ArgumentBuilders.literal("resetash")
+        commandDispatcher.register(ClientCommandManager.literal("resetash")
             .executes(context -> {
                 config = new AshConfig();
                 AshMod.configManager.save();
                 return 1;
             }));
 
-        commandDispatcher.register(ArgumentBuilders.literal("alignash")
-            .then(ArgumentBuilders.literal("left")
+        commandDispatcher.register(ClientCommandManager.literal("alignash")
+            .then(ClientCommandManager.literal("left")
                     .executes(context -> {
                         config.align = 0;
                         AshMod.configManager.save();
                         return 1;
                     }))
-            .then(ArgumentBuilders.literal("center")
+            .then(ClientCommandManager.literal("center")
                     .executes(context -> {
                         config.align = 1;
                         AshMod.configManager.save();
                         return 1;
                     }))
-            .then(ArgumentBuilders.literal("right")
+            .then(ClientCommandManager.literal("right")
                     .executes(context -> {
                         config.align = 2;
                         AshMod.configManager.save();

--- a/src/main/java/com/umollu/ash/AshMod.java
+++ b/src/main/java/com/umollu/ash/AshMod.java
@@ -46,6 +46,8 @@ public class AshMod implements ClientModInitializer {
         }, (field) -> {
             return field.getName().equals("align");
         });
+        
+        AshCommands.registerCommands();
     }
 
     private String alignToString(int align) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
     "umollu_ash.mixins.json"
   ],
   "depends": {
-    "fabric": "*"
+    "fabric": ">=0.31.0"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,6 @@
     "umollu_ash.mixins.json"
   ],
   "depends": {
-    "fabric": "*",
-    "cotton-client-commands": "^1.0.0"
+    "fabric": "*"
   }
 }


### PR DESCRIPTION
Fabric API 0.31 introduced a way to register client-side commands exactly as you'd expect it. I find it'd be nicer to use it!

Aditionally, I updated Gradle because the previous doesn't work with Java 15.