### PR TITLE
Overhaul and unify commands into a single command tree

### DIFF
--- a/src/main/java/com/umollu/ash/AshCommands.java
+++ b/src/main/java/com/umollu/ash/AshCommands.java
@@ -1,11 +1,12 @@
 package com.umollu.ash;
 
-import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.umollu.ash.config.AshConfig;
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import net.fabricmc.fabric.api.client.command.v1.ClientCommandManager;
-import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
 
 public class AshCommands {
 
@@ -13,98 +14,100 @@ public class AshCommands {
 
         public static void registerCommands() {
 
-        CommandDispatcher<FabricClientCommandSource> commandDispatcher = ClientCommandManager.DISPATCHER;
-        
         if(config == null) {
             config = AutoConfig.getConfigHolder(AshConfig.class).getConfig();
         }
-        commandDispatcher.register(ClientCommandManager.literal("toggleash")
-            .executes(context -> {
-                config.showHud = !config.showHud;
-                AshMod.configManager.save();
-                return 1;
-            }));
 
-        commandDispatcher.register(ClientCommandManager.literal("togglefps")
-            .executes(context -> {
-                config.showFps = !config.showFps;
-                AshMod.configManager.save();
-                return 1;
-            }));
-
-        commandDispatcher.register(ClientCommandManager.literal("togglecoords")
-            .executes(context -> {
-                config.showCoords = !config.showCoords;
-                AshMod.configManager.save();
-                return 1;
-            }));
-
-        commandDispatcher.register(ClientCommandManager.literal("toggledirection")
-            .executes(context -> {
-                config.showDirection = !config.showDirection;
-                AshMod.configManager.save();
-                return 1;
-            }));
-
-        commandDispatcher.register(ClientCommandManager.literal("ashcolor")
+        ClientCommandManager.DISPATCHER.register(ClientCommandManager.literal("ash")
+        .then(ClientCommandManager.literal("color")
             .then(ClientCommandManager.argument("r", IntegerArgumentType.integer())
-                    .then(ClientCommandManager.argument("g", IntegerArgumentType.integer())
-                            .then(ClientCommandManager.argument("b", IntegerArgumentType.integer())
-                                    .executes(context -> {
-                                        int r = IntegerArgumentType.getInteger(context,"r");
-                                        int g = IntegerArgumentType.getInteger(context,"g");
-                                        int b = IntegerArgumentType.getInteger(context,"b");
-
-                                        config.hudColor = b + (g << 8) + (r << 16);
-                                        AshMod.configManager.save();
-                                        return 1;
-                                    })))));
-
-        commandDispatcher.register(ClientCommandManager.literal("resetash")
+                .then(ClientCommandManager.argument("g", IntegerArgumentType.integer())
+                    .then(ClientCommandManager.argument("b", IntegerArgumentType.integer())
+                        .executes(context -> {
+                            int r = IntegerArgumentType.getInteger(context,"r");
+                            int g = IntegerArgumentType.getInteger(context,"g");
+                            int b = IntegerArgumentType.getInteger(context,"b");
+                            config.hudColor = b + (g << 8) + (r << 16);
+                            AshMod.configManager.save();
+                            return 1;
+                        })))))
+        .then(ClientCommandManager.literal("halign")
+            .then(ClientCommandManager.literal("left")
+                .executes(context -> {
+                    config.align = 0;
+                    AshMod.configManager.save();
+                    return 1;
+                }))
+            .then(ClientCommandManager.literal("center")
+                .executes(context -> {
+                    config.align = 1;
+                    AshMod.configManager.save();
+                    return 1;
+                }))
+            .then(ClientCommandManager.literal("right")
+                .executes(context -> {
+                    config.align = 2;
+                    AshMod.configManager.save();
+                    return 1;
+                })))
+        .then(ClientCommandManager.literal("valign")
+            .then(ClientCommandManager.literal("top")
+                .executes(context -> {
+                    config.verticalAlign = 0;
+                    AshMod.configManager.save();
+                    return 1;
+                }))
+            .then(ClientCommandManager.literal("middle")
+                .executes(context -> {
+                    config.verticalAlign = 1;
+                    AshMod.configManager.save();
+                    return 1;
+                }))
+            .then(ClientCommandManager.literal("bottom")
+                .executes(context -> {
+                    config.verticalAlign = 2;
+                    AshMod.configManager.save();
+                    return 1;
+                })))
+        .then(ClientCommandManager.literal("toggle")
+            .then(ClientCommandManager.literal("enabled")
+                .executes(context -> {
+                    config.showHud = !config.showHud;
+                    AshMod.configManager.save();
+                    return 1;
+                }))
+            .then(ClientCommandManager.literal("coords")
+                .executes(context -> {
+                    config.showCoords = !config.showCoords;
+                    msg("toggle.coords." + config.showCoords);
+                    AshMod.configManager.save();
+                    return 1;
+                }))
+            .then(ClientCommandManager.literal("diretion")
+                .executes(context -> {
+                    config.showDirection = !config.showDirection;
+                    msg("toggle.direction." + config.showDirection);
+                    AshMod.configManager.save();
+                    return 1;
+                }))
+            .then(ClientCommandManager.literal("fps")
+                .executes(context -> {
+                    config.showFps = !config.showFps;
+                    msg("toggle.fps." + config.showFps);
+                    AshMod.configManager.save();
+                    return 1;
+                })))
+        .then(ClientCommandManager.literal("reset")
             .executes(context -> {
                 config = new AshConfig();
+                msg("reset");
                 AshMod.configManager.save();
                 return 1;
-            }));
+            })));
+    }
 
-        commandDispatcher.register(ClientCommandManager.literal("alignash")
-            .then(ClientCommandManager.literal("left")
-                    .executes(context -> {
-                        config.align = 0;
-                        AshMod.configManager.save();
-                        return 1;
-                    }))
-            .then(ClientCommandManager.literal("center")
-                    .executes(context -> {
-                        config.align = 1;
-                        AshMod.configManager.save();
-                        return 1;
-                    }))
-            .then(ClientCommandManager.literal("right")
-                    .executes(context -> {
-                        config.align = 2;
-                        AshMod.configManager.save();
-                        return 1;
-                    })));
-
-        commandDispatcher.register(ClientCommandManager.literal("valignash")
-            .then(ClientCommandManager.literal("top")
-                    .executes(context -> {
-                        config.verticalAlign = 0;
-                        AshMod.configManager.save();
-                        return 1;
-                    }))
-            .then(ClientCommandManager.literal("middle")
-                    .executes(context -> {
-                        config.verticalAlign = 1;
-                        AshMod.configManager.save();
-                        return 1;
-                    }))
-            .then(ClientCommandManager.literal("bottom")
-                    .executes(context -> {
-                        config.verticalAlign = 2;
-                        AshMod.configManager.save();
-                        return 1;
-                    })));
+    private static void msg(String message) {
+        MinecraftClient instance = MinecraftClient.getInstance();
+        instance.inGameHud.getChatHud().addMessage(new TranslatableText("command.ash." + message).formatted(Formatting.GRAY));
     }
 }

--- a/src/main/resources/assets/umollu_ash/lang/en_us.json
+++ b/src/main/resources/assets/umollu_ash/lang/en_us.json
@@ -7,5 +7,12 @@
   "text.autoconfig.umollu_ash.option.showDirection" : "Show direction",
   "text.autoconfig.umollu_ash.option.align" : "HUD screen horizontal alignment",
   "text.autoconfig.umollu_ash.option.verticalAlign" : "HUD screen vertical alignment",
-  "key.umollu_ash.toggleAsh" : "Toggle ASH HUD"
+  "key.umollu_ash.toggleAsh" : "Toggle ASH HUD",
+  "command.ash.toggle.coords.true" : "Enabled coords on HUD",
+  "command.ash.toggle.coords.false" : "Disabled coords from HUD",
+  "command.ash.toggle.direction.true" : "Enabled direction display on HUD",
+  "command.ash.toggle.direction.false" : "Disabled direction display from HUD",
+  "command.ash.toggle.fps.true" : "Enabled FPS counter on HUD",
+  "command.ash.toggle.fps.false" : "Disabled FPS counter from HUD",
+  "command.ash.reset" : "Reset ASH HUD's settings to defaults"
 }


### PR DESCRIPTION
The current commands clutter the tab list because there are many of them, and they do one small thing. The new commands are unified under `/ash`. Additionally, info toggle commands will now give feedback in chat.

The `/ash` command tree is:
- `/ash color <r> <g> <b>`
- `/ash halign <center|left|right>`
- `/ash reset`
- `/ash toggle <coords|direction|enabled|fps>`
- `/ash valign <bottom|middle|top>`